### PR TITLE
Remove -m64 and -fPIC compiller options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if (WIN32)
     set_target_properties(spice PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 else ()
     target_compile_definitions(spice PRIVATE NON_ANSI_STDIO)
-    target_compile_options(spice PRIVATE -m64 -ansi -fPIC)
+    target_compile_options(spice PRIVATE -ansi)
 endif ()
 
 if (MSVC)


### PR DESCRIPTION
m64 is enabled automatically when building for 64bit platform and should not be used on 32bit platform. It also is not portable, at least arm64 doesn't support it.
fPIC is enabled with property POSITION_INDEPENDENT_CODE set earlier