### PR TITLE
Set C_STANDARD to 90

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ else ()
   add_library(spice STATIC ${SPICE_COMMON_SOURCE} ${SPICE_PLATFORM_SOURCE})
 endif ()
 set_target_properties(spice PROPERTIES POSITION_INDEPENDENT_CODE 1)
+set_target_properties(spice PROPERTIES C_STANDARD 90)
 target_include_directories(spice PUBLIC "${INCLUDE_PATH}")
 
 if (WIN32)


### PR DESCRIPTION
Clang 16 fails to compile this if the C standard is set to 99 or above, due to the use of implicit int return types in some functions, e.g. https://github.com/OpenSpace/Spice/blob/499b72fe301732f6f7b7d2b9ab55e973aca9a3d5/src/common/dfe.c#LL5C6-L5C6

To avoid compilation failures, explicitly set the C standard to use when compiling.